### PR TITLE
feat: new TlsConnector

### DIFF
--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -4,8 +4,8 @@ use std::marker::Unpin;
 use futures_io::{AsyncRead, AsyncWrite};
 use native_tls::Error;
 
-use crate::TlsStream;
 use crate::handshake::handshake;
+use crate::TlsStream;
 
 /// A wrapper around a `native_tls::TlsAcceptor`, providing an async `accept`
 /// method.
@@ -42,4 +42,3 @@ impl From<native_tls::TlsAcceptor> for TlsAcceptor {
         TlsAcceptor(inner)
     }
 }
-

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -13,48 +13,7 @@ use crate::TlsStream;
 pub(crate) struct TlsConnector(native_tls::TlsConnector);
 
 impl TlsConnector {
-    /// Connects the provided stream with this connector, assuming the provided
-    /// domain.
-    ///
-    /// This function will internally call `TlsConnector::connect` to connect
-    /// the stream and returns a future representing the resolution of the
-    /// connection operation. The returned future will resolve to either
-    /// `TlsStream<S>` or `Error` depending if it's successful or not.
-    ///
-    /// This is typically used for clients who have already established, for
-    /// example, a TCP connection to a remote server. That stream is then
-    /// provided here to perform the client half of a connection to a
-    /// TLS-powered server.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::prelude::*;
-    /// use std::net::ToSocketAddrs;
-    ///
-    /// let socket = async_std::net::TcpStream::connect("google.com:443").await?;
-    ///
-    /// // Configure using the regular native_tls::TlsConnector.
-    /// let builder = native_tls::TlsConnector::builder();
-    ///
-    /// let connector: async_native_tls::TlsConnector = builder.build()?.into();
-    ///
-    /// let mut socket = connector.connect("google.com", socket).await?;
-    /// socket.write_all(b"GET / HTTP/1.0\r\n\r\n").await?;
-    ///
-    /// let mut data = Vec::new();
-    /// socket.read_to_end(&mut data).await?;
-    ///
-    /// // any response code is fine
-    /// assert!(data.starts_with(b"HTTP/1.0 "));
-    ///
-    /// let data = String::from_utf8_lossy(&data);
-    /// let data = data.trim_end();
-    /// assert!(data.ends_with("</html>") || data.ends_with("</HTML>"));
-    /// #
-    /// # Ok(()) }) }
+    /// Connects the provided stream with this connector, assuming the provided domain.
     pub(crate) async fn connect<S>(&self, domain: &str, stream: S) -> Result<TlsStream<S>, Error>
     where
         S: AsyncRead + AsyncWrite + Unpin,

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -10,7 +10,7 @@ use crate::TlsStream;
 /// A wrapper around a `native_tls::TlsConnector`, providing an async `connect`
 /// method.
 #[derive(Clone)]
-pub struct TlsConnector(native_tls::TlsConnector);
+pub(crate) struct TlsConnector(native_tls::TlsConnector);
 
 impl TlsConnector {
     /// Connects the provided stream with this connector, assuming the provided
@@ -55,7 +55,7 @@ impl TlsConnector {
     /// assert!(data.ends_with("</html>") || data.ends_with("</HTML>"));
     /// #
     /// # Ok(()) }) }
-    pub async fn connect<S>(&self, domain: &str, stream: S) -> Result<TlsStream<S>, Error>
+    pub(crate) async fn connect<S>(&self, domain: &str, stream: S) -> Result<TlsStream<S>, Error>
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -8,8 +8,8 @@ use std::task::{Context, Poll};
 use futures_io::{AsyncRead, AsyncWrite};
 use native_tls::{Error, HandshakeError, MidHandshakeTlsStream};
 
-use crate::TlsStream;
 use crate::std_adapter::StdAdapter;
+use crate::TlsStream;
 
 pub(crate) async fn handshake<F, S>(f: F, stream: S) -> Result<TlsStream<S>, Error>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,14 +35,18 @@ mod std_adapter;
 mod tls_stream;
 
 pub use acceptor::TlsAcceptor;
-pub use connect::connect;
-pub use connector::TlsConnector;
+pub use connect::{connect, TlsConnector};
 pub use tls_stream::TlsStream;
 
+#[doc(inline)]
+use native_tls::{Certificate, Identity, Protocol};
+
 mod connect {
-    use crate::TlsConnector;
-    use crate::TlsStream;
     use futures_io::{AsyncRead, AsyncWrite};
+    use std::fmt::{self, Debug};
+
+    use crate::TlsStream;
+    use crate::{Certificate, Identity, Protocol};
 
     /// Connect a client to a remote server.
     ///
@@ -68,10 +72,160 @@ mod connect {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        let builder = native_tls::TlsConnector::builder();
-        let connector = builder.build()?;
-        let connector = TlsConnector::from(connector);
-        let stream = connector.connect(domain, stream).await?;
+        let stream = TlsConnector::new().connect(domain, stream).await?;
         Ok(stream)
+    }
+
+    /// Connect a client to a remote server.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::prelude::*;
+    /// use async_std::net::TcpStream;
+    /// use async_native_tls::TlsConnector;
+    ///
+    /// let stream = TcpStream::connect("google.com:443").await?;
+    /// let mut stream = TlsConnector::new()
+    ///     .use_sni(true)
+    ///     .connect("google.com", stream)
+    ///     .await?;
+    /// stream.write_all(b"GET / HTTP/1.0\r\n\r\n").await?;
+    ///
+    /// let mut res = Vec::new();
+    /// stream.read_to_end(&mut res).await?;
+    /// println!("{}", String::from_utf8_lossy(&res));
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub struct TlsConnector {
+        builder: native_tls::TlsConnectorBuilder,
+    }
+
+    impl TlsConnector {
+        /// Create a new instance.
+        pub fn new() -> Self {
+            Self {
+                builder: native_tls::TlsConnector::builder(),
+            }
+        }
+
+        /// Sets the identity to be used for client certificate authentication.
+        pub fn identity(mut self, identity: Identity) -> Self {
+            self.builder.identity(identity);
+            self
+        }
+
+        /// Sets the minimum supported protocol version.
+        ///
+        /// A value of `None` enables support for the oldest protocols supported by the
+        /// implementation. Defaults to `Some(Protocol::Tlsv10)`.
+        pub fn min_protocol_version(&mut self, protocol: Option<Protocol>) -> &mut Self {
+            self.builder.min_protocol_version(protocol);
+            self
+        }
+
+        /// Sets the maximum supported protocol version.
+        ///
+        /// A value of `None` enables support for the newest protocols supported by the
+        /// implementation. Defaults to `None`.
+        pub fn max_protocol_version(&mut self, protocol: Option<Protocol>) -> &mut Self {
+            self.builder.max_protocol_version(protocol);
+            self
+        }
+
+        /// Adds a certificate to the set of roots that the connector will trust.
+        ///
+        /// The connector will use the system's trust root by default. This method can be used to
+        /// add to that set when communicating with servers not trusted by the system. Defaults to
+        /// an empty set.
+        pub fn add_root_certificate(&mut self, cert: Certificate) -> &mut Self {
+            self.builder.add_root_certificate(cert);
+            self
+        }
+
+        /// Controls the use of certificate validation.
+        ///
+        /// Defaults to false.
+        ///
+        /// # Warning
+        ///
+        /// You should think very carefully before using this method. If invalid certificates are
+        /// trusted, any certificate for any site will be trusted for use. This includes expired
+        /// certificates. This introduces significant vulnerabilities, and should only be used as a
+        /// last resort.
+        pub fn danger_accept_invalid_certs(&mut self, accept_invalid_certs: bool) -> &mut Self {
+            self.builder
+                .danger_accept_invalid_certs(accept_invalid_certs);
+            self
+        }
+
+        /// Controls the use of Server Name Indication (SNI).
+        ///
+        /// Defaults to `true`.
+        pub fn use_sni(&mut self, use_sni: bool) -> &mut Self {
+            self.builder.use_sni(use_sni);
+            self
+        }
+
+        /// Controls the use of hostname verification.
+        ///
+        /// Defaults to `false`.
+        ///
+        /// # Warning
+        ///
+        /// You should think very carefully before using this method. If invalid hostnames are
+        /// trusted, any valid certificate for any site will be trusted for use. This introduces
+        /// significant vulnerabilities, and should only be used as a last resort.
+        pub fn danger_accept_invalid_hostnames(
+            &mut self,
+            accept_invalid_hostnames: bool,
+        ) -> &mut Self {
+            self.builder
+                .danger_accept_invalid_hostnames(accept_invalid_hostnames);
+            self
+        }
+
+        /// Connect to a remote server.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+        /// #
+        /// use async_std::prelude::*;
+        /// use async_std::net::TcpStream;
+        /// use async_native_tls::TlsConnector;
+        ///
+        /// let stream = TcpStream::connect("google.com:443").await?;
+        /// let mut stream = TlsConnector::new()
+        ///     .use_sni(true)
+        ///     .connect("google.com", stream)
+        ///     .await?;
+        /// stream.write_all(b"GET / HTTP/1.0\r\n\r\n").await?;
+        ///
+        /// let mut res = Vec::new();
+        /// stream.read_to_end(&mut res).await?;
+        /// println!("{}", String::from_utf8_lossy(&res));
+        /// #
+        /// # Ok(()) }) }
+        /// ```
+        pub async fn connect<S>(self, domain: &str, stream: S) -> native_tls::Result<TlsStream<S>>
+        where
+            S: AsyncRead + AsyncWrite + Unpin,
+        {
+            let connector = self.builder.build()?;
+            let connector = crate::connector::TlsConnector::from(connector);
+            let stream = connector.connect(domain, stream).await?;
+            Ok(stream)
+        }
+    }
+
+    impl Debug for TlsConnector {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("TlsConnector").finish()
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod connect {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
     /// #
     /// use async_std::prelude::*;
@@ -80,7 +80,7 @@ mod connect {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
     /// #
     /// use async_std::prelude::*;
@@ -122,7 +122,7 @@ mod connect {
         ///
         /// A value of `None` enables support for the oldest protocols supported by the
         /// implementation. Defaults to `Some(Protocol::Tlsv10)`.
-        pub fn min_protocol_version(&mut self, protocol: Option<Protocol>) -> &mut Self {
+        pub fn min_protocol_version(mut self, protocol: Option<Protocol>) -> Self {
             self.builder.min_protocol_version(protocol);
             self
         }
@@ -131,7 +131,7 @@ mod connect {
         ///
         /// A value of `None` enables support for the newest protocols supported by the
         /// implementation. Defaults to `None`.
-        pub fn max_protocol_version(&mut self, protocol: Option<Protocol>) -> &mut Self {
+        pub fn max_protocol_version(mut self, protocol: Option<Protocol>) -> Self {
             self.builder.max_protocol_version(protocol);
             self
         }
@@ -141,7 +141,7 @@ mod connect {
         /// The connector will use the system's trust root by default. This method can be used to
         /// add to that set when communicating with servers not trusted by the system. Defaults to
         /// an empty set.
-        pub fn add_root_certificate(&mut self, cert: Certificate) -> &mut Self {
+        pub fn add_root_certificate(mut self, cert: Certificate) -> Self {
             self.builder.add_root_certificate(cert);
             self
         }
@@ -165,7 +165,7 @@ mod connect {
         /// Controls the use of Server Name Indication (SNI).
         ///
         /// Defaults to `true`.
-        pub fn use_sni(&mut self, use_sni: bool) -> &mut Self {
+        pub fn use_sni(mut self, use_sni: bool) -> Self {
             self.builder.use_sni(use_sni);
             self
         }
@@ -180,9 +180,9 @@ mod connect {
         /// trusted, any valid certificate for any site will be trusted for use. This introduces
         /// significant vulnerabilities, and should only be used as a last resort.
         pub fn danger_accept_invalid_hostnames(
-            &mut self,
+            mut self,
             accept_invalid_hostnames: bool,
-        ) -> &mut Self {
+        ) -> Self {
             self.builder
                 .danger_accept_invalid_hostnames(accept_invalid_hostnames);
             self
@@ -192,7 +192,7 @@ mod connect {
         ///
         /// # Examples
         ///
-        /// ```no_run
+        /// ```
         /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
         /// #
         /// use async_std::prelude::*;


### PR DESCRIPTION
Follow-up to #5. Introduces a new `TlsConnector` struct that removes the need to hop between `native-tls` and `async-native-tls`, and allows us to configure things in a single go. The `accept` method is just a shorthand for building a `TlsConnector` with the default config and then accepting a connection.

Thanks!