### PR TITLE
feat: replace async-std dependency with futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,17 @@ categories = ["asynchronous", "cryptography", "network-programming"]
 native-tls = "0.2.3"
 thiserror = "1.0.9"
 async-std = { version = "1.4.0", default-features = false, features = ["std"], optional = true }
+futures-util = { version = "0.3.1", features = ["io"], optional = true }
 tokio = { version = "0.2.9", default-features = false, features = ["io-util"], optional = true }
 
 [features]
-default = ["runtime-async-std"]
+default = ["runtime-futures"]
 
 vendored = ["native-tls/vendored"]
 
 # Runtime
 runtime-async-std = ["async-std"]
+runtime-futures = ["futures-util"]
 runtime-tokio = ["tokio"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = { version = "0.3.1", features = ["io"], optional = true }
 tokio = { version = "0.2.9", default-features = false, features = ["io-util"], optional = true }
 
 [features]
-default = ["runtime-futures"]
+default = ["runtime-async-std"]
 
 vendored = ["native-tls/vendored"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ categories = ["asynchronous", "cryptography", "network-programming"]
 [dependencies]
 native-tls = "0.2.3"
 thiserror = "1.0.9"
-async-std = { version = "1.4.0", default-features = false, features = ["std"], optional = true }
 futures-util = { version = "0.3.1", features = ["io"], optional = true }
 tokio = { version = "0.2.9", default-features = false, features = ["io-util"], optional = true }
 
@@ -27,8 +26,7 @@ default = ["runtime-async-std"]
 vendored = ["native-tls/vendored"]
 
 # Runtime
-runtime-async-std = ["async-std"]
-runtime-futures = ["futures-util"]
+runtime-async-std = ["futures-util"]
 runtime-tokio = ["tokio"]
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,21 +31,11 @@
 //! # fn main() {}
 //! ```
 
-#[cfg(not(any(
-    feature = "runtime-tokio",
-    feature = "runtime-async-std",
-    feature = "runtime-futures"
-)))]
-compile_error!(
-    "one of 'runtime-async-std' or 'runtime-tokio' or 'runtime-futures' features must be enabled"
-);
+#[cfg(not(any(feature = "runtime-tokio", feature = "runtime-async-std")))]
+compile_error!("one of 'runtime-async-std' or 'runtime-tokio' features must be enabled");
 
-#[cfg(all(
-    feature = "runtime-tokio",
-    feature = "runtime-async-std",
-    feature = "runtime-futures"
-))]
-compile_error!("only one of 'runtime-async-std' or 'runtime-tokio' or 'runtime-futures' features must be enabled");
+#[cfg(all(feature = "runtime-tokio", feature = "runtime-async-std"))]
+compile_error!("only one of 'runtime-async-std' or 'runtime-tokio' features must be enabled");
 
 mod acceptor;
 mod connector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,11 +31,21 @@
 //! # fn main() {}
 //! ```
 
-#[cfg(not(any(feature = "runtime-tokio", feature = "runtime-async-std")))]
-compile_error!("one of 'runtime-async-std' or 'runtime-tokio' features must be enabled");
+#[cfg(not(any(
+    feature = "runtime-tokio",
+    feature = "runtime-async-std",
+    feature = "runtime-futures"
+)))]
+compile_error!(
+    "one of 'runtime-async-std' or 'runtime-tokio' or 'runtime-futures' features must be enabled"
+);
 
-#[cfg(all(feature = "runtime-tokio", feature = "runtime-async-std"))]
-compile_error!("only one of 'runtime-async-std' or 'runtime-tokio' features must be enabled");
+#[cfg(all(
+    feature = "runtime-tokio",
+    feature = "runtime-async-std",
+    feature = "runtime-futures"
+))]
+compile_error!("only one of 'runtime-async-std' or 'runtime-tokio' or 'runtime-futures' features must be enabled");
 
 mod acceptor;
 mod connector;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5,5 +5,12 @@ pub(crate) use async_std::io::{Read as AsyncRead, Write as AsyncWrite};
 #[allow(unused_imports)]
 pub(crate) use async_std::io::prelude::{ReadExt as AsyncReadExt, WriteExt as AsyncWriteExt};
 
+#[cfg(feature = "runtime-futures")]
+pub(crate) use futures_util::io::{AsyncRead, AsyncWrite};
+
+#[cfg(feature = "runtime-futures")]
+#[allow(unused_imports)]
+pub(crate) use futures_util::io::{AsyncReadExt, AsyncWriteExt};
+
 #[cfg(feature = "runtime-tokio")]
 pub(crate) use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,14 +1,7 @@
 #[cfg(feature = "runtime-async-std")]
-pub(crate) use async_std::io::{Read as AsyncRead, Write as AsyncWrite};
-
-#[cfg(feature = "runtime-async-std")]
-#[allow(unused_imports)]
-pub(crate) use async_std::io::prelude::{ReadExt as AsyncReadExt, WriteExt as AsyncWriteExt};
-
-#[cfg(feature = "runtime-futures")]
 pub(crate) use futures_util::io::{AsyncRead, AsyncWrite};
 
-#[cfg(feature = "runtime-futures")]
+#[cfg(feature = "runtime-async-std")]
 #[allow(unused_imports)]
 pub(crate) use futures_util::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -50,7 +50,7 @@ impl<S> TlsStream<S> {
     }
 
     /// Returns the number of bytes that can be read without resulting in any network calls.
-    pub fn buffered_read_size(&self) -> crate::Result<usize> 
+    pub fn buffered_read_size(&self) -> crate::Result<usize>
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
@@ -58,7 +58,7 @@ impl<S> TlsStream<S> {
     }
 
     /// Returns the peer's leaf certificate, if available.
-    pub fn peer_certificate(&self) -> crate::Result<Option<crate::Certificate>> 
+    pub fn peer_certificate(&self) -> crate::Result<Option<crate::Certificate>>
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
@@ -103,7 +103,7 @@ where
         self.with_context(ctx, |s| cvt(s.flush()))
     }
 
-    #[cfg(feature = "runtime-async-std")]
+    #[cfg(any(feature = "runtime-async-std", feature = "runtime-futures",))]
     fn poll_close(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match self.with_context(ctx, |s| s.shutdown()) {
             Ok(()) => Poll::Ready(Ok(())),

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -103,7 +103,7 @@ where
         self.with_context(ctx, |s| cvt(s.flush()))
     }
 
-    #[cfg(any(feature = "runtime-async-std", feature = "runtime-futures",))]
+    #[cfg(feature = "runtime-async-std")]
     fn poll_close(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match self.with_context(ctx, |s| s.shutdown()) {
             Ok(()) => Poll::Ready(Ok(())),


### PR DESCRIPTION
The async-std runtime shares traits with the futures crate, and async-native-tls doesn't really use anything else besides those traits. Therefore, we can just switch the async-std dependency with futures.

This PR inherits #14.
Closes #10.