### PR TITLE
Use panic with a format specifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
         rust: [nightly, beta, stable]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@master

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -523,7 +523,7 @@ async fn one_byte_at_a_time() {
             match socket.read_exact(&mut buf).await {
                 Ok(_) => data.extend_from_slice(&buf),
                 Err(ref err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                Err(err) => panic!(err),
+                Err(err) => panic!("{}", err),
             }
         }
         data


### PR DESCRIPTION
The bare form is no longer accepted by nightly compiler.

Also updates CI to not abort all jobs if one from the matrix fails.
This is useful to see if e.g. an issue only occurs on a nightly
compiler.