### PR TITLE
Use a format string for panic!()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest]
         rust: [nightly, beta, stable]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -523,7 +523,7 @@ async fn one_byte_at_a_time() {
             match socket.read_exact(&mut buf).await {
                 Ok(_) => data.extend_from_slice(&buf),
                 Err(ref err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                Err(err) => panic!(err),
+                Err(err) => panic!("{}", err),
             }
         }
         data


### PR DESCRIPTION
Newer compilers are unhappy about this, seems like it was an accident
this ever worked.