### PR TITLE
Introduce a trait to abstract over async tls acceptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "1.0.9"
 futures-util = { version = "0.3.1", features = ["io"], optional = true }
 tokio = { version = "1.0", default-features = false, features = ["io-util"], optional = true }
 url = "2.1.1"
+async-tls-acceptor = { version = "0.1.0", optional = true }
 
 [features]
 default = ["runtime-async-std"]
@@ -27,7 +28,7 @@ default = ["runtime-async-std"]
 vendored = ["native-tls/vendored"]
 
 # Runtime
-runtime-async-std = ["futures-util"]
+runtime-async-std = ["futures-util", "async-tls-acceptor"]
 runtime-tokio = ["tokio"]
 
 [dev-dependencies]

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -96,6 +96,20 @@ impl From<native_tls::TlsAcceptor> for TlsAcceptor {
     }
 }
 
+#[cfg(feature = "runtime-async-std")]
+#[async_tls_acceptor::async_trait]
+impl<Input> async_tls_acceptor::Acceptor<Input> for TlsAcceptor
+where
+    Input: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+{
+    type Output = TlsStream<Input>;
+    type Error = crate::Error;
+
+    async fn accept(&self, input: Input) -> Result<Self::Output, Self::Error> {
+        TlsAcceptor::accept(&self, input).await
+    }
+}
+
 #[cfg(all(test, feature = "runtime-async-std"))]
 mod tests {
     use super::*;


### PR DESCRIPTION
I've decided to try moving forward with [async-tls-acceptor](https://docs.rs/async-tls-acceptor/0.1.0/async_tls_acceptor/) even though I haven't heard back on async-tls. If this goes well, I'll take a look at connectors as well. See smol-rs/async-rustls#7 for the equivalent PR on a rustls-based tls implementation.

This is only implemented for async-std runtime, because the trait has futures-based AsyncRead and AsyncWrite bounds.

Thanks!

closes #27 