### PR TITLE
Update rust-native-tls and dev-dependencies to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["asynchronous", "cryptography", "network-programming"]
 
 
 [dependencies]
-native-tls = "0.2.3"
+native-tls = "0.2.8"
 thiserror = "1.0.9"
 futures-util = { version = "0.3.1", features = ["io"], optional = true }
 tokio = { version = "1.0", default-features = false, features = ["io-util"], optional = true }
@@ -31,10 +31,10 @@ runtime-async-std = ["futures-util"]
 runtime-tokio = ["tokio"]
 
 [dev-dependencies]
-env_logger = "0.7.1"
+env_logger = "0.9.0"
 async-std = { version = "1.6.0", features = ["attributes"] }
 tokio = { version = "1.0", features = ["full"] }
-cfg-if = "0.1.10"
+cfg-if = "1.0.0"
 futures = "0.3.1"
 
 [[test]]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -523,7 +523,7 @@ async fn one_byte_at_a_time() {
             match socket.read_exact(&mut buf).await {
                 Ok(_) => data.extend_from_slice(&buf),
                 Err(ref err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                Err(err) => panic!(err),
+                Err(err) => panic!("{}", err),
             }
         }
         data


### PR DESCRIPTION
rust-native-tls 0.23 is pretty old (2019) and lacks more recent [ALPN support](https://github.com/sfackler/rust-native-tls/pull/194), needed for HTTP/2.

Updates some dev-dependencies to latest as well.

Lastly cleans up a compile warning that was seen when running `cargo test` (probably a new check in recent rustc?)